### PR TITLE
PLAT-74449: Add support for robust metadata retrieval during logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,21 +110,18 @@ const resolveLabel = (node) => {
 };
 
 // Default message formatter
-const formatMessage = (node, {type}) => {
+const format = (node, ev) => {
+    const {type} = ev;
     if (node) {
         return {
             time: Date.now(),
             type,
-            label: resolveLabel(node)
+            label: resolveLabel(node),
+            ...(config.format && config.format(node, ev) || null)
         };
     }
 
     return null;
-};
-
-// Invokes the config's format function (if it exists) and returns the result
-const format = (target, ev) => {
-    return config.format && config.format(target, ev) || formatMessage(target, ev);
 };
 
 const logJob = new Job(flushLogQueue);

--- a/preset/ilib.js
+++ b/preset/ilib.js
@@ -1,0 +1,38 @@
+import ResBundle from '@enact/i18n/ilib/lib/ResBundle';
+
+import {configure as conf} from '../index';
+
+const config = {
+    format: (msg) => {
+        // Retrieve the ResBundle to get access to the string map for the current locale.
+		const resBundle = new ResBundle();
+        const map = resBundle.getResObj();
+
+        // For every key (except type and time), attempt to delocalize the string.
+		Object.keys(msg).filter(key => key !== 'type' && key !== 'time').forEach(msgKey => {
+            // We have to convert the case since the text may be converted by UI components to a
+            // different case during render.
+			const upperValue = msg[msgKey].toUpperCase();
+			const value = Object.keys(map).find(key => upperValue === map[key].toUpperCase());
+
+			if (value) {
+				msg[msgKey] = value;
+			}
+		});
+
+		return msg;
+	}
+};
+
+const configure = (cfg) => {
+    conf({
+        ...config,
+        ...cfg
+    });
+};
+
+export default configure;
+export {
+    config,
+    configure
+};

--- a/preset/webos.js
+++ b/preset/webos.js
@@ -3,10 +3,12 @@ import {info} from '@enact/webos/pmloglib';
 
 import {configure as conf, fetchConfig} from '../index';
 
+let messageId = 'NL_ENACT';
+
 const config = {
     enabled: false,
     log: (message) => {
-        info('NL_ENACT', message);
+        info(messageId, message);
     }
 };
 
@@ -31,8 +33,9 @@ const configure = (cfg) => {
         sync: true,
         parse: (body) => {
             const json = JSON.parse(body);
-            // if the file is found, treat it as enabled
-            json.enabled = true;
+            if (json.messageId) {
+                messageId = json.messageId;
+            }
 
             return json;
         }

--- a/preset/webos.js
+++ b/preset/webos.js
@@ -24,8 +24,7 @@ const configure = (cfg) => {
         // retrieve a local config file so bail out
         if (!appId) return;
 
-        // TODO: Determine the default path on webOS
-        path = `/usr/var/${appId}.json`
+        path = `/mnt/lg/cmn_data/whitelist/dr/enact/${appId}.json`
     }
 
     fetchConfig(path, {

--- a/preset/webos.js
+++ b/preset/webos.js
@@ -6,7 +6,7 @@ import {configure as conf, fetchConfig} from '../index';
 const config = {
     enabled: false,
     log: (message) => {
-        info('@enact/analytics', message);
+        info('NL_ENACT', message);
     }
 };
 

--- a/preset/webostv.js
+++ b/preset/webostv.js
@@ -1,8 +1,10 @@
 import {config as moonstone} from './moonstone';
+import {config as ilib} from './ilib';
 import {config as webos, configure as conf} from './webos';
 
 const config = {
     ...moonstone,
+    ...ilib,
     ...webos
 };
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [X] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The `config.format` method provided an imperative interface for retrieving additional metadata for a given event but it could not be configured via an external configuration limiting its usefulness.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add `data` prop to support declarative metadata retrieval
* Change `format` prop to only format the generated message rather than generate a message from the event. This works better with the new `data` prop which can produce a more robust payload but still allow the app to convert the message object either to another format (e.g. a string) or a different object structure based on its requirements.

### Usage Examples

I've included some high level documentation in the code but until we have proper documentation, I wanted to include some examples and explanations here.

> _The examples below are in JS object format as would be passed to `configure()` and not JSON format which would be fetched by `fetchConfig()`._

* Add the spotlight ID

```
data: {
    // retrieves the data-spotlight-id attribute from the node
    spotlightId: 'data-spotlight-id'
}
```

* Add the nearest spotlight container's spotlight ID

```
data: {
    containerId: {
        // find the first ancestor for data-spotlight-container
        closest: '[data-spotlight-container]',
        // and retrieve its data-spotlight-id attribute
        value: 'data-spotlight-id'
    }
}
```

* Add the text of the first `moonstone/Icon` within the target

```
data: {
    icon: {
        // only try to add this metadata if the target node matches this selector
        matches: '[role = "button"]`,
        // find the first descendant with a class attribute containing Icon_icon
        selector: '[class *= "Icon_icon"]',
        // and use the special <text> token to retrieve its textContent value
        value: '<text>'
    }
}
```

* Add the title of the `moonstone/Panel` that contains the target

> This illustrates that the `value` of a resolver can itself be another resolver allowing you to navigate to an intermediate shared reference point in order to get relevant data.

```
data: {
    panel: {
        // find the first Panel ancestor
        closest: "article[role='region']",
        value: {
            // from that Panel node, find the first h1 descendant
            selector: "header h1",
            // and retrieve its textContent
            value: "<text>"
        }
    }
}
```

* Add the first of several potential sources

```
data: {
    // Retrieves the first attribute in the list that is valued
    id: ['id', 'data-spotlight-id', 'data-component-id']
}
```


* Add the text or image url of the first `moonstone/Icon` within the target

```
data: {
    icon: {
        // only try to add this metadata if the target node matches this selector
        matches: '[role = "button"]`,
        // find the first descendant with a class attribute containing Icon_icon
        selector: '[class *= "Icon_icon"]',
        value: [
            // retrieve the textContent if it exists
            '<text>',
            {
                // if not, retrieve the style attribute
                value: 'style',
                // and try to match on the url() within it using a regular expression.
                // The expression will be passed to RegExp. If it includes a capture group,
                // the first capture will be returned. If not, the matching string will be returned.
                expression: 'url\(.*\/(.*)\)'
            }
        ]
    }
}
```