### PR TITLE
PLAT-75744: Add support for <value> pseudo-attribute value

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,10 @@ const resolveAttribute = (name) => (node) => {
         return node.textContent;
     }
 
+    if (name === '<value>') {
+        return node.type === 'password' ? null : node.value;
+    }
+
     return node.getAttribute(name);
 };
 

--- a/tests/data-specs.js
+++ b/tests/data-specs.js
@@ -29,6 +29,27 @@ describe('configure data', () => {
 			const log = mountTriggerEvent({data});
 			expect(log.mock.calls[0][0].altLabel).toBe('First Button');
 		});
+		test('base case of a simple <value> pseudo-attribute', () => {
+			const data = {
+				innerText: '<value>'
+			};
+			const log = mountTriggerEvent({data, target: '#data-input-text'});
+			expect(log.mock.calls[0][0].innerText).toBe('plain text value');
+		});
+		test('base case of a simple <value> pseudo-attribute on <select>', () => {
+			const data = {
+				innerText: '<value>'
+			};
+			const log = mountTriggerEvent({data, target: '#data-input-select'});
+			expect(log.mock.calls[0][0].innerText).toBe('selected option');
+		});
+		test('base case of a simple <value> pseudo-attribute on password field', () => {
+			const data = {
+				innerText: '<value>'
+			};
+			const log = mountTriggerEvent({data, target: '#data-input-password'});
+			expect(log.mock.calls[0][0].innerText).not.toBeDefined();
+		});
 		test('advanced case of a object <text> value', () => {
 			const data = {
 				sectionTitle: {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -3,7 +3,7 @@ import {mount} from 'enzyme';
 import React from 'react';
 
 const defaultTarget = '#test-target';
-const defaultConfig = {enabled: true, selector: 'button', idle: false};
+const defaultConfig = {enabled: true, selector: '[id]', idle: false};
 const container = document.body.appendChild(document.createElement('div'));
 
 // Keymap for keydown usage
@@ -27,6 +27,12 @@ const basicApp = (
 			</button>
 			<button id="data-button" data-metric-label="Data metric label" aria-label="Aria label">Click Me</button>
 			<button id="aria-button" aria-label="Aria label">Click Me</button>
+			<input id="data-input-text" type="text" defaultValue="plain text value" />
+			<input id="data-input-password" type="password" defaultValue="p@ssw0rd" />
+			<select id="data-input-select" defaultValue="selected option">
+				<option value="selected option">Selected Option</option>
+				<option value="unselected option">Unselected Option</option>
+			</select>
 		</section>
 	</article>
 );


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Feature request to include `input` values in the message payload.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Adds ability to extract the `value` of a form field (except `type="password"`) into the analytics message payload.
