### PR TITLE
PLAT-76029: Improve performance of ilib string mapping

### DIFF
--- a/preset/ilib.js
+++ b/preset/ilib.js
@@ -25,7 +25,7 @@ const config = {
 	format: (msg) => {
 		const findValue = getMapper();
 
-		// For every key (except type and time), attempt to delocalize the string.
+		// For every string value (except type), attempt to delocalize the string.
 		Object.keys(msg)
 			.filter(key => key !== 'type' && typeof msg[key] === 'string')
 			.forEach(msgKey => {

--- a/preset/ilib.js
+++ b/preset/ilib.js
@@ -11,9 +11,12 @@ const memoMapper = memoize((/* locale */) => {
 
     // We have to convert the case since the text may be converted by UI components to a
     // different case during render.
-    const keys = Object.keys(map).map(s => s.toUpperCase());
+    const reversed = Object.keys(map).reduce((acc, key) => {
+        acc[map[key].toUpperCase()] = key;
+        return acc;
+    }, {});
 
-    return (value) => keys[keys.indexOf(value.toUpperCase())];
+    return (value) => reversed[value.toUpperCase()];
 });
 
 const getMapper = () => memoMapper(ilib.getLocale());

--- a/preset/ilib.js
+++ b/preset/ilib.js
@@ -1,24 +1,37 @@
+import {memoize} from '@enact/core/util';
+import ilib from '@enact/i18n';
 import ResBundle from '@enact/i18n/ilib/lib/ResBundle';
 
 import {configure as conf} from '../index';
 
+const memoMapper = memoize((/* locale */) => {
+    // Retrieve the ResBundle to get access to the string map for the current locale.
+    const resBundle = new ResBundle();
+    const map = resBundle.getResObj();
+
+    // We have to convert the case since the text may be converted by UI components to a
+    // different case during render.
+    const keys = Object.keys(map).map(s => s.toUpperCase());
+
+    return (value) => keys[keys.indexOf(value.toUpperCase())];
+});
+
+const getMapper = () => memoMapper(ilib.getLocale());
+
 const config = {
     format: (msg) => {
-        // Retrieve the ResBundle to get access to the string map for the current locale.
-		const resBundle = new ResBundle();
-        const map = resBundle.getResObj();
+        const findValue = getMapper();
 
         // For every key (except type and time), attempt to delocalize the string.
-		Object.keys(msg).filter(key => key !== 'type' && key !== 'time').forEach(msgKey => {
-            // We have to convert the case since the text may be converted by UI components to a
-            // different case during render.
-			const upperValue = msg[msgKey].toUpperCase();
-			const value = Object.keys(map).find(key => upperValue === map[key].toUpperCase());
+        Object.keys(msg)
+            .filter(key => key !== 'type' && typeof msg[key] === 'string')
+            .forEach(msgKey => {
+                const value = findValue(msg[msgKey]);
 
-			if (value) {
-				msg[msgKey] = value;
-			}
-		});
+                if (value) {
+                    msg[msgKey] = value;
+                }
+            });
 
 		return msg;
 	}

--- a/preset/ilib.js
+++ b/preset/ilib.js
@@ -42,8 +42,14 @@ const config = {
 
 const configure = (cfg) => {
     conf({
-        ...config,
-        ...cfg
+        ...cfg,
+        format: (msg) => {
+            if (cfg && cfg.format) {
+                msg = cfg.format(msg);
+            }
+
+            return config.format(msg);
+        }
     });
 };
 

--- a/tests/preset-specs.js
+++ b/tests/preset-specs.js
@@ -50,6 +50,21 @@ describe('preset', () => {
 			expect(msg.otherData).toBe('something else');
 			expect(msg.label).toBe('stringName');
 		});
+
+		test('calls provided format function before intrinsic format function', () => {
+			// remaps message fields to validate it was called
+			const customFormat = jest.fn(message => ({
+				content: message.label
+			}));
+			ilib.configure({
+				format: customFormat
+			});
+
+			const format = configure.mock.calls[0][0].format;
+			const msg = format({label: 'localized text'});
+
+			expect(msg.content).toBe('stringName');
+		});
 	});
 
 	describe('#webos', () => {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The construction cost of a ResBundle is small (~1ms at 6x slowdown) but is significant relative to the overall cost of formatting a message (~0.1ms at 6x slowdown).

**Timing for formatting 5 messages**
![image](https://user-images.githubusercontent.com/788456/54705516-3b60f480-4afa-11e9-99ad-e1c123bdbddf.png)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Update the ilib formatter to construct a "reverse" map of translated string to source strings per locale
* Memoize the map retrieval by locale which changes infrequently

The result is a reduction of the ilib formatting to ~0.01ms at 6x slowdown.

**Timing for formatting 5 messages**
![image](https://user-images.githubusercontent.com/788456/54705637-84b14400-4afa-11e9-9f64-d3293effe405.png)
