### PR TITLE
PLAT-75962: Analytics webos preset fails in isomorphic builds

### DIFF
--- a/preset/webos.js
+++ b/preset/webos.js
@@ -1,3 +1,4 @@
+import {onWindowReady} from '@enact/core/snapshot';
 import {fetchAppId} from '@enact/webos/application';
 import {info} from '@enact/webos/pmloglib';
 
@@ -18,27 +19,29 @@ const configure = (cfg = {}) => {
 		...cfg
 	});
 
-	let {path} = cfg;
-	if (!path) {
-		const appId = fetchAppId();
+	onWindowReady(() => {
+		let {path} = cfg;
+		if (!path) {
+			const appId = fetchAppId();
 
-		// if we lack a path and can't parse an app id, we won't be able to
-		// retrieve a local config file so bail out
-		if (!appId) return;
+			// if we lack a path and can't parse an app id, we won't be able to
+			// retrieve a local config file so bail out
+			if (!appId) return;
 
-		path = `/mnt/lg/cmn_data/whitelist/dr/enact/${appId}.json`;
-	}
-
-	fetchConfig(path, {
-		sync: true,
-		parse: (body) => {
-			const json = JSON.parse(body);
-			if (json.messageId) {
-				messageId = json.messageId;
-			}
-
-			return json;
+			path = `/mnt/lg/cmn_data/whitelist/dr/enact/${appId}.json`;
 		}
+
+		fetchConfig(path, {
+			sync: true,
+			parse: (body) => {
+				const json = JSON.parse(body);
+				if (json.messageId) {
+					messageId = json.messageId;
+				}
+
+				return json;
+			}
+		});
 	});
 };
 

--- a/preset/webos.js
+++ b/preset/webos.js
@@ -13,40 +13,42 @@ const config = {
 	}
 };
 
+const fetchAppConfig = path => {
+	if (!path) {
+		const appId = fetchAppId();
+
+		// if we lack a path and can't parse an app id, we won't be able to
+		// retrieve a local config file so bail out
+		if (!appId) return;
+
+		path = `/mnt/lg/cmn_data/whitelist/dr/enact/${appId}.json`;
+	}
+
+	fetchConfig(path, {
+		sync: true,
+		parse: (body) => {
+			const json = JSON.parse(body);
+			if (json.messageId) {
+				messageId = json.messageId;
+			}
+
+			return json;
+		}
+	});
+};
+
 const configure = (cfg = {}) => {
 	conf({
 		...config,
 		...cfg
 	});
 
-	onWindowReady(() => {
-		let {path} = cfg;
-		if (!path) {
-			const appId = fetchAppId();
-
-			// if we lack a path and can't parse an app id, we won't be able to
-			// retrieve a local config file so bail out
-			if (!appId) return;
-
-			path = `/mnt/lg/cmn_data/whitelist/dr/enact/${appId}.json`;
-		}
-
-		fetchConfig(path, {
-			sync: true,
-			parse: (body) => {
-				const json = JSON.parse(body);
-				if (json.messageId) {
-					messageId = json.messageId;
-				}
-
-				return json;
-			}
-		});
-	});
+	onWindowReady(() => fetchAppConfig(cfg.path));
 };
 
 export default configure;
 export {
 	config,
-	configure
+	configure,
+	fetchAppConfig
 };


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
* `fetchAppId` and `fetchConfig` were being called inline during initial `configure`, which is designed to be run at the modular scope. This prevents correct usage in prerendering as well as snapshot.


### Resolution
* Ensure parts of webOS preset code that require a `window` to be wrapped within `onWindowReady` callback, similar to how listeners are added within the core analytics script.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>