### PR TITLE
PLAT-75973: Add support for <count>

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ const buildDataResolver = (data) => {
 	const result = {};
 	Object.keys(data).forEach(key => {
 		const resolver = buildResolver(data[key]);
-		if (resolver != null) {
+		if (resolver) {
 			result[key] = resolver;
 		}
 	});

--- a/index.js
+++ b/index.js
@@ -144,18 +144,28 @@ const matchesRules = (ruleset, msg) => Object.keys(ruleset).some(key => {
 	return !!msg[key] && ruleset[key].test(msg[key]);
 });
 
+const getFirstNode = (nodeOrList) => {
+	return nodeOrList instanceof global.HTMLElement ? nodeOrList : nodeOrList[0];
+};
+
 const resolveAttribute = (name) => (node) => {
-	if (!node) return null;
+	if (!node || node.length === 0) return null;
+
+	if (name === '<count>') {
+		return node.length || 1;
+	}
+
+	const first = getFirstNode(node);
 
 	if (name === '<text>') {
-		return node.textContent;
+		return first.textContent;
 	}
 
 	if (name === '<value>') {
-		return node.type === 'password' ? null : node.value;
+		return first.type === 'password' ? null : first.value;
 	}
 
-	return node.getAttribute(name);
+	return first.getAttribute(name);
 };
 
 // Returns a function that accepts a value and uses the provided expression to match against that
@@ -196,7 +206,7 @@ const resolveNode = (closestSelector, selector) => (node) => {
 	if (closestSelector) {
 		return node.closest(closestSelector);
 	} else if (selector) {
-		return node.querySelector(selector);
+		return node.querySelectorAll(selector);
 	}
 
 	return node;
@@ -227,7 +237,7 @@ const buildResolver = (elementConfig) => {
 	const expressionResolver = resolveExpression(expression);
 
 	return (node) => {
-		if (matches && !node.matches(matches)) return null;
+		if (matches && !getFirstNode(node).matches(matches)) return null;
 
 		return expressionResolver(valueResolver(nodeResolver(node)));
 	};

--- a/index.js
+++ b/index.js
@@ -22,8 +22,13 @@ const config = {
 	//     AttributeName = String
 	//     RegularExpressionString = String
 	//     TextContentSelector = '<text>'
+	//     ValueContentSelector = '<value>'
+	//     CountContentSelector = '<count>'
 	//
-	//     AttributeSelector = AttributeName | TextContentSelector
+	//     AttributeSelector = AttributeName |
+	//                         TextContentSelector |
+	//                         ValueContentSelector |
+	//                         CountContentSelector
 	//     ClosestSelector = CssSelector
 	//     Selector = CssSelector
 	//     Matches = CssSelector

--- a/index.js
+++ b/index.js
@@ -154,11 +154,13 @@ const getFirstNode = (nodeOrList) => {
 };
 
 const resolveAttribute = (name) => (node) => {
-	if (!node || node.length === 0) return null;
-
+	// normally, if node isn't found, we bail on data resolution. <count> is the exception in which
+	// we'll return 0 if the node isn't found and it's the last in the resolution chain.
 	if (name === '<count>') {
-		return node.length || 1;
+		return node ? (node.length || 1) : 0;
 	}
+
+	if (!node || node.length === 0) return null;
 
 	const first = getFirstNode(node);
 
@@ -242,7 +244,7 @@ const buildResolver = (elementConfig) => {
 	const expressionResolver = resolveExpression(expression);
 
 	return (node) => {
-		if (matches && !getFirstNode(node).matches(matches)) return null;
+		if (!node || matches && !getFirstNode(node).matches(matches)) return null;
 
 		return expressionResolver(valueResolver(nodeResolver(node)));
 	};
@@ -255,7 +257,7 @@ const buildDataResolver = (data) => {
 	const result = {};
 	Object.keys(data).forEach(key => {
 		const resolver = buildResolver(data[key]);
-		if (resolver) {
+		if (resolver != null) {
 			result[key] = resolver;
 		}
 	});
@@ -289,7 +291,7 @@ const resolveData = (node) => {
 	const result = {};
 	Object.keys(config.data).forEach(key => {
 		const value = config.data[key](node);
-		if (value) {
+		if (value != null) {
 			result[key] = value;
 		}
 	});

--- a/tests/data-specs.js
+++ b/tests/data-specs.js
@@ -60,6 +60,39 @@ describe('configure data', () => {
 			const log = mountTriggerEvent({data, target: '#data-list'});
 			expect(log.mock.calls[0][0].count).toBe(5);
 		});
+		test('base case of <count> pseudo-attribute with closest', () => {
+			const data = {
+				count: {
+					closest: 'section',
+					value: '<count>'
+				}
+			};
+			const log = mountTriggerEvent({data, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBe(1);
+		});
+		test('advanced case of <count> pseudo-attribute with not found closest', () => {
+			const data = {
+				count: {
+					closest: 'does-not-exist',
+					value: '<count>'
+				}
+			};
+			const log = mountTriggerEvent({data, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBe(0);
+		});
+		test('advanced case of <count> pseudo-attribute with not found closest and value selector', () => {
+			const data = {
+				count: {
+					closest: 'does-not-exist',
+					value: {
+						selector: 'section',
+						value: '<count>'
+					}
+				}
+			};
+			const log = mountTriggerEvent({data, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBeUndefined();
+		});
 		test('advanced case of a object <text> value', () => {
 			const data = {
 				sectionTitle: {

--- a/tests/data-specs.js
+++ b/tests/data-specs.js
@@ -50,6 +50,16 @@ describe('configure data', () => {
 			const log = mountTriggerEvent({data, target: '#data-input-password'});
 			expect(log.mock.calls[0][0].innerText).not.toBeDefined();
 		});
+		test('base case of <count> pseudo-attribute', () => {
+			const data = {
+				count: {
+					selector: 'li',
+					value: '<count>'
+				}
+			};
+			const log = mountTriggerEvent({data, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBe(5);
+		});
 		test('advanced case of a object <text> value', () => {
 			const data = {
 				sectionTitle: {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -33,6 +33,13 @@ const basicApp = (
 				<option value="selected option">Selected Option</option>
 				<option value="unselected option">Unselected Option</option>
 			</select>
+			<ul id="data-list">
+				<li>Item</li>
+				<li>Item</li>
+				<li>Item</li>
+				<li>Item</li>
+				<li>Item</li>
+			</ul>
 		</section>
 	</article>
 );


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Ability to count the number of items in a list

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a `<count>` pseudo-attribute which returns the number of nodes that match `selector`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This will not adequately address virtualized lists which should instead rely on the `aria-setsize` attribute set on list items.
