### PR TITLE
PLAT-76274: Add rules config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+
 /* global XMLHttpRequest */
 /* eslint no-console: "off" */
 
@@ -80,8 +81,6 @@ const config = {
 	// Enables metric logging
 	enabled: false,
 
-	entries: null,
-
 	// Function accepting the message -- which includes the time, type, label, and output of `data`
 	// resolvers -- and returning a log entry in whichever format the application chooses.
 	format: null,
@@ -102,6 +101,8 @@ const config = {
 
 	// Required application-defined function to log the events
 	log: null,
+
+	rules: null,
 
 	// A CSS selector which finds the closest ancestor from the target of an event to consider as
 	// the source for the purposes of logging
@@ -331,9 +332,9 @@ const idle = (msg) => {
 };
 
 const matchEntry = (ev) => {
-	if (!config.entries || config.entries.length === 0) return;
+	if (!config.rules || config.rules.length === 0) return;
 
-	return config.entries.reduce((result, entry) => {
+	return config.rules.reduce((result, entry) => {
 		if (result) return result;
 
 		const msg = format(entry, ev);
@@ -413,7 +414,7 @@ const configureEntry = (cfg = {}) => {
 
 // Configures the logging behavior
 const configure = (cfg = {}) => {
-	if (Array.isArray(cfg.entries))        config.entries = cfg.entries.map(configureEntry);
+	if (Array.isArray(cfg.rules))        config.rules = cfg.rules.map(configureEntry);
 	if (typeof cfg.format === 'function')  config.format = cfg.format;
 	if (typeof cfg.frameSize === 'number') config.frameSize = cfg.frameSize;
 	if (typeof cfg.idle === 'boolean')     config.idle = cfg.idle;

--- a/index.js
+++ b/index.js
@@ -332,13 +332,12 @@ const idle = (msg) => {
 };
 
 const matchEntry = (ev) => {
-	if (!config.rules || config.rules.length === 0) return;
+	if (!config.rules) return format({}, ev);
 
 	return config.rules.reduce((result, entry) => {
 		if (result) return result;
 
 		const msg = format(entry, ev);
-		// console.log(msg);
 		if (filter(entry, msg)) {
 			return msg;
 		}

--- a/index.js
+++ b/index.js
@@ -338,7 +338,7 @@ const matchEntry = (ev) => {
 		if (result) return result;
 
 		const msg = format(entry, ev);
-		if (filter(entry, msg)) {
+		if (msg && filter(entry, msg)) {
 			return msg;
 		}
 	}, null);

--- a/tests/configure-specs.js
+++ b/tests/configure-specs.js
@@ -50,27 +50,27 @@ describe('configure', () => {
 	describe('#exclude', () => {
 		test('non-existant key does not prevent the log output', () => {
 			const exclude = {unusedProp: 'test'};
-			const log = mountTriggerEvent({exclude});
+			const log = mountTriggerEvent({entries: [{exclude}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which does not string match, allows log entry in output', () => {
 			const exclude = {label: 'unused'};
-			const log = mountTriggerEvent({exclude});
+			const log = mountTriggerEvent({entries: [{exclude}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which does not match within string array, allows log entry in output', () => {
 			const exclude = {label: ['unused1', 'unused2']};
-			const log = mountTriggerEvent({exclude});
+			const log = mountTriggerEvent({entries: [{exclude}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which has a string match, excludes log entry from output', () => {
 			const exclude = {label: 'Aria'};
-			const log = mountTriggerEvent({exclude, target: '#aria-button'});
+			const log = mountTriggerEvent({entries: [{exclude}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('validate existing key, which has a match within string array, excludes log entry from output', () => {
 			const exclude = {label: ['Aria', 'Other']};
-			const log = mountTriggerEvent({exclude, target: '#aria-button'});
+			const log = mountTriggerEvent({entries: [{exclude}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(0);
 		});
 	});
@@ -78,27 +78,27 @@ describe('configure', () => {
 	describe('#include', () => {
 		test('non-existant key does not allow the log output', () => {
 			const include = {unusedProp: 'test'};
-			const log = mountTriggerEvent({include});
+			const log = mountTriggerEvent({entries: [{include}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('existing key, which does not string match, excludes log entry from output', () => {
 			const include = {label: 'unused'};
-			const log = mountTriggerEvent({include});
+			const log = mountTriggerEvent({entries: [{include}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('existing key, which does not match within string array, excludes log entry from output', () => {
 			const include = {label: ['unused1', 'unused2']};
-			const log = mountTriggerEvent({include});
+			const log = mountTriggerEvent({entries: [{include}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('existing key, which has a string match, allows log entry in output', () => {
 			const include = {label: 'Aria'};
-			const log = mountTriggerEvent({include, target: '#aria-button'});
+			const log = mountTriggerEvent({entries: [{include}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which has a match within string array, allows log entry in output', () => {
 			const include = {label: ['Aria', 'Other']};
-			const log = mountTriggerEvent({include, target: '#aria-button'});
+			const log = mountTriggerEvent({entries: [{include}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(1);
 		});
 	});
@@ -106,12 +106,12 @@ describe('configure', () => {
 	describe('#filter', () => {
 		test('falsey return prevents log output', () => {
 			const filter = () => false;
-			const log = mountTriggerEvent({filter});
+			const log = mountTriggerEvent({entries: [{filter}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('truthy return allows log output', () => {
 			const filter = () => true;
-			const log = mountTriggerEvent({filter});
+			const log = mountTriggerEvent({entries: [{filter}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 	});
@@ -256,7 +256,7 @@ describe('configure', () => {
 			const log = mountTriggerEvent({idle: false});
 			expect(log.mock.calls.length).toBe(1);
 		});
-		test('log flushing waits for system idle state when`idle` is true', done => {
+		test('log flushing waits for system idle state when `idle` is true', done => {
 			const log = mountTriggerEvent({idle: true});
 			expect(log.mock.calls.length).toBe(0);
 			const after = new Job(() => {

--- a/tests/configure-specs.js
+++ b/tests/configure-specs.js
@@ -50,27 +50,27 @@ describe('configure', () => {
 	describe('#exclude', () => {
 		test('non-existant key does not prevent the log output', () => {
 			const exclude = {unusedProp: 'test'};
-			const log = mountTriggerEvent({entries: [{exclude}]});
+			const log = mountTriggerEvent({rules: [{exclude}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which does not string match, allows log entry in output', () => {
 			const exclude = {label: 'unused'};
-			const log = mountTriggerEvent({entries: [{exclude}]});
+			const log = mountTriggerEvent({rules: [{exclude}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which does not match within string array, allows log entry in output', () => {
 			const exclude = {label: ['unused1', 'unused2']};
-			const log = mountTriggerEvent({entries: [{exclude}]});
+			const log = mountTriggerEvent({rules: [{exclude}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which has a string match, excludes log entry from output', () => {
 			const exclude = {label: 'Aria'};
-			const log = mountTriggerEvent({entries: [{exclude}], target: '#aria-button'});
+			const log = mountTriggerEvent({rules: [{exclude}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('validate existing key, which has a match within string array, excludes log entry from output', () => {
 			const exclude = {label: ['Aria', 'Other']};
-			const log = mountTriggerEvent({entries: [{exclude}], target: '#aria-button'});
+			const log = mountTriggerEvent({rules: [{exclude}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(0);
 		});
 	});
@@ -78,27 +78,27 @@ describe('configure', () => {
 	describe('#include', () => {
 		test('non-existant key does not allow the log output', () => {
 			const include = {unusedProp: 'test'};
-			const log = mountTriggerEvent({entries: [{include}]});
+			const log = mountTriggerEvent({rules: [{include}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('existing key, which does not string match, excludes log entry from output', () => {
 			const include = {label: 'unused'};
-			const log = mountTriggerEvent({entries: [{include}]});
+			const log = mountTriggerEvent({rules: [{include}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('existing key, which does not match within string array, excludes log entry from output', () => {
 			const include = {label: ['unused1', 'unused2']};
-			const log = mountTriggerEvent({entries: [{include}]});
+			const log = mountTriggerEvent({rules: [{include}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('existing key, which has a string match, allows log entry in output', () => {
 			const include = {label: 'Aria'};
-			const log = mountTriggerEvent({entries: [{include}], target: '#aria-button'});
+			const log = mountTriggerEvent({rules: [{include}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(1);
 		});
 		test('existing key, which has a match within string array, allows log entry in output', () => {
 			const include = {label: ['Aria', 'Other']};
-			const log = mountTriggerEvent({entries: [{include}], target: '#aria-button'});
+			const log = mountTriggerEvent({rules: [{include}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(1);
 		});
 	});
@@ -106,12 +106,12 @@ describe('configure', () => {
 	describe('#filter', () => {
 		test('falsey return prevents log output', () => {
 			const filter = () => false;
-			const log = mountTriggerEvent({entries: [{filter}]});
+			const log = mountTriggerEvent({rules: [{filter}]});
 			expect(log.mock.calls.length).toBe(0);
 		});
 		test('truthy return allows log output', () => {
 			const filter = () => true;
-			const log = mountTriggerEvent({entries: [{filter}]});
+			const log = mountTriggerEvent({rules: [{filter}]});
 			expect(log.mock.calls.length).toBe(1);
 		});
 	});

--- a/tests/data-specs.js
+++ b/tests/data-specs.js
@@ -6,230 +6,363 @@ describe('configure data', () => {
 
 	describe('#value', () => {
 		test('base case of a simple <text> pseudo-attribute', () => {
-			const data = {
-				innerText: '<text>'
+			const cfg = {
+				entries: [
+					{
+						data: {
+							innerText: '<text>'
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data, target: '#data-button'});
+			const log = mountTriggerEvent({...cfg, target: '#data-button'});
 			expect(log.mock.calls[0][0].innerText).toBe('Click Me');
 		});
 		test('base case of a simple attribute selector', () => {
-			const data = {
-				altLabel: 'alt'
+			const cfg = {
+				entries: [
+					{
+						data: {
+							altLabel: 'alt'
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].altLabel).toBe('First Button');
 		});
 		test('base case of a simple value selector with nothing else', () => {
 			// Special edge case of no selector nor closest in object format
-			const data = {
-				altLabel: {
-					value: 'alt'
-				}
-			};
-			const log = mountTriggerEvent({data});
-			expect(log.mock.calls[0][0].altLabel).toBe('First Button');
-		});
-		test('base case of a simple <value> pseudo-attribute', () => {
-			const data = {
-				innerText: '<value>'
-			};
-			const log = mountTriggerEvent({data, target: '#data-input-text'});
-			expect(log.mock.calls[0][0].innerText).toBe('plain text value');
-		});
-		test('base case of a simple <value> pseudo-attribute on <select>', () => {
-			const data = {
-				innerText: '<value>'
-			};
-			const log = mountTriggerEvent({data, target: '#data-input-select'});
-			expect(log.mock.calls[0][0].innerText).toBe('selected option');
-		});
-		test('base case of a simple <value> pseudo-attribute on password field', () => {
-			const data = {
-				innerText: '<value>'
-			};
-			const log = mountTriggerEvent({data, target: '#data-input-password'});
-			expect(log.mock.calls[0][0].innerText).not.toBeDefined();
-		});
-		test('base case of <count> pseudo-attribute', () => {
-			const data = {
-				count: {
-					selector: 'li',
-					value: '<count>'
-				}
-			};
-			const log = mountTriggerEvent({data, target: '#data-list'});
-			expect(log.mock.calls[0][0].count).toBe(5);
-		});
-		test('base case of <count> pseudo-attribute with closest', () => {
-			const data = {
-				count: {
-					closest: 'section',
-					value: '<count>'
-				}
-			};
-			const log = mountTriggerEvent({data, target: '#data-list'});
-			expect(log.mock.calls[0][0].count).toBe(1);
-		});
-		test('advanced case of <count> pseudo-attribute with not found closest', () => {
-			const data = {
-				count: {
-					closest: 'does-not-exist',
-					value: '<count>'
-				}
-			};
-			const log = mountTriggerEvent({data, target: '#data-list'});
-			expect(log.mock.calls[0][0].count).toBe(0);
-		});
-		test('advanced case of <count> pseudo-attribute with not found closest and value selector', () => {
-			const data = {
-				count: {
-					closest: 'does-not-exist',
-					value: {
-						selector: 'section',
-						value: '<count>'
-					}
-				}
-			};
-			const log = mountTriggerEvent({data, target: '#data-list'});
-			expect(log.mock.calls[0][0].count).toBeUndefined();
-		});
-		test('advanced case of a object <text> value', () => {
-			const data = {
-				sectionTitle: {
-					selector: 'header h1',
-					value: '<text>'
-				}
-			};
-			const log = mountTriggerEvent({data, selector: 'article'});
-			expect(log.mock.calls[0][0].sectionTitle).toBe('Header Text');
-		});
-		test('advanced case of a object attribute value', () => {
-			const data = {
-				sectionIndex: {
-					closest: 'section',
-					value: 'data-section-index'
-				}
-			};
-			const log = mountTriggerEvent({data});
-			expect(log.mock.calls[0][0].sectionIndex).toBe('0');
-		});
-		test('advanced case of a array of resolver strings, returning first match', () => {
-			const data = {
-				id: ['id', 'data-spotlight-id', 'data-component-id']
-			};
-			const log = mountTriggerEvent({data});
-			expect(log.mock.calls[0][0].id).toBe('test-target');
-		});
-		test('advanced case of a array of resolver value objects, returning first match', () => {
-			const data = {
-				sectionIndex: [
+			const cfg = {
+				entries: [
 					{
-						closest: 'p',
-						value: 'data-section-index'
-					},
-					{
-						closest: 'section',
-						value: 'data-section-index'
+						data: {
+							altLabel: {
+								value: 'alt'
+							}
+						}
 					}
 				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
+			expect(log.mock.calls[0][0].altLabel).toBe('First Button');
+		});
+		test('base case of a simple <value> pseudo-attribute', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							innerText: '<value>'
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, target: '#data-input-text'});
+			expect(log.mock.calls[0][0].innerText).toBe('plain text value');
+		});
+		test('base case of a simple <value> pseudo-attribute on <select>', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							innerText: '<value>'
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, target: '#data-input-select'});
+			expect(log.mock.calls[0][0].innerText).toBe('selected option');
+		});
+		test('base case of a simple <value> pseudo-attribute on password field', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							innerText: '<value>'
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, target: '#data-input-password'});
+			expect(log.mock.calls[0][0].innerText).not.toBeDefined();
+		});
+		test('base case of <count> pseudo-attribute', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							count: {
+								selector: 'li',
+								value: '<count>'
+							}
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBe(5);
+		});
+		test('base case of <count> pseudo-attribute with closest', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							count: {
+								closest: 'section',
+								value: '<count>'
+							}
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBe(1);
+		});
+		test('advanced case of <count> pseudo-attribute with not found closest', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							count: {
+								closest: 'does-not-exist',
+								value: '<count>'
+							}
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBe(0);
+		});
+		test('advanced case of <count> pseudo-attribute with not found closest and value selector', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							count: {
+								closest: 'does-not-exist',
+								value: {
+									selector: 'section',
+									value: '<count>'
+								}
+							}
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, target: '#data-list'});
+			expect(log.mock.calls[0][0].count).toBeUndefined();
+		});
+		test('advanced case of a object <text> value', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							sectionTitle: {
+								selector: 'header h1',
+								value: '<text>'
+							}
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent({...cfg, selector: 'article'});
+			expect(log.mock.calls[0][0].sectionTitle).toBe('Header Text');
+		});
+		test('advanced case of a object attribute value', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							sectionIndex: {
+								closest: 'section',
+								value: 'data-section-index'
+							}
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent(cfg);
+			expect(log.mock.calls[0][0].sectionIndex).toBe('0');
+		});
+		test('advanced case of a array of resolver strings, returning first match', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							id: ['id', 'data-spotlight-id', 'data-component-id']
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent(cfg);
+			expect(log.mock.calls[0][0].id).toBe('test-target');
+		});
+		test('advanced case of a array of resolver value objects, returning first match', () => {
+			const cfg = {
+				entries: [
+					{
+						data: {
+							sectionIndex: [
+								{
+									closest: 'p',
+									value: 'data-section-index'
+								},
+								{
+									closest: 'section',
+									value: 'data-section-index'
+								}
+							]
+						}
+					}
+				]
+			};
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].sectionIndex).toBe('0');
 		});
 	});
 
 	describe('#closest', () => {
 		test('base case of using closest where data is found', () => {
-			const data = {
-				sectionIndex: {
-					closest: 'section',
-					value: 'data-section-index'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							sectionIndex: {
+								closest: 'section',
+								value: 'data-section-index'
+							}
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].sectionIndex).toBe('0');
 		});
 		test('base case of using closest where nothing is found', () => {
-			const data = {
-				sectionIndex: {
-					closest: 'p',
-					value: 'data-section-index'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							sectionIndex: {
+								closest: 'p',
+								value: 'data-section-index'
+							}
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].sectionIndex).toBeUndefined();
 		});
 	});
 
 	describe('#selector', () => {
 		test('base case of using selector where data is found', () => {
-			const data = {
-				iconUrl: {
-					selector: '[role=icon]',
-					value: 'src'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							iconUrl: {
+								selector: '[role=icon]',
+								value: 'src'
+							}
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].iconUrl).toBe('https://via.placeholder.com/50');
 		});
 		test('base case of using selector where nothing is found', () => {
-			const data = {
-				iconUrl: {
-					selector: '[role=other]',
-					value: 'src'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							iconUrl: {
+								selector: '[role=other]',
+								value: 'src'
+							}
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].iconUrl).toBeUndefined();
 		});
 	});
 
 	describe('#matches', () => {
 		test('base case of using matches where data is found', () => {
-			const data = {
-				iconUrl: {
-					matches: '[alt]', // matches #test-target, which has alt attribute
-					selector: 'img',
-					value: 'src'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							iconUrl: {
+								matches: '[alt]', // matches #test-target, which has alt attribute
+								selector: 'img',
+								value: 'src'
+							}
+
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].iconUrl).toBe('https://via.placeholder.com/50');
 		});
 		test('base case of using matches where nothing is found', () => {
-			const data = {
-				iconUrl: {
-					matches: '[alt]',
-					selector: 'img',
-					value: 'src'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							iconUrl: {
+								matches: '[alt]',
+								selector: 'img',
+								value: 'src'
+							}
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data, target: '#aria-button'});
+			const log = mountTriggerEvent({...cfg, target: '#aria-button'});
 			expect(log.mock.calls[0][0].iconUrl).toBeUndefined();
 		});
 	});
 
 	describe('#expression', () => {
 		test('base case of using expression where data is matched', () => {
-			const data = {
-				avatarHost: {
-					selector: 'img[role=avatar]',
-					value: 'src',
-					expression: 'https://(.*)/.*'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							avatarHost: {
+								selector: 'img[role=avatar]',
+								value: 'src',
+								expression: 'https://(.*)/.*'
+							}
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].avatarHost).toBe('via.placeholder.com');
 		});
 		test('base case of using expression where nothing is matched', () => {
-			const data = {
-				avatarHost: {
-					selector: 'img[role=avatar]',
-					value: 'src',
-					expression: 'ftp://(.*)/.*'
-				}
+			const cfg = {
+				entries: [
+					{
+						data: {
+							avatarHost: {
+								selector: 'img[role=avatar]',
+								value: 'src',
+								expression: 'ftp://(.*)/.*'
+							}
+						}
+					}
+				]
 			};
-			const log = mountTriggerEvent({data});
+			const log = mountTriggerEvent(cfg);
 			expect(log.mock.calls[0][0].avatarHost).toBeUndefined();
 		});
 	});

--- a/tests/data-specs.js
+++ b/tests/data-specs.js
@@ -7,7 +7,7 @@ describe('configure data', () => {
 	describe('#value', () => {
 		test('base case of a simple <text> pseudo-attribute', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							innerText: '<text>'
@@ -20,7 +20,7 @@ describe('configure data', () => {
 		});
 		test('base case of a simple attribute selector', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							altLabel: 'alt'
@@ -34,7 +34,7 @@ describe('configure data', () => {
 		test('base case of a simple value selector with nothing else', () => {
 			// Special edge case of no selector nor closest in object format
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							altLabel: {
@@ -49,7 +49,7 @@ describe('configure data', () => {
 		});
 		test('base case of a simple <value> pseudo-attribute', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							innerText: '<value>'
@@ -62,7 +62,7 @@ describe('configure data', () => {
 		});
 		test('base case of a simple <value> pseudo-attribute on <select>', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							innerText: '<value>'
@@ -75,7 +75,7 @@ describe('configure data', () => {
 		});
 		test('base case of a simple <value> pseudo-attribute on password field', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							innerText: '<value>'
@@ -88,7 +88,7 @@ describe('configure data', () => {
 		});
 		test('base case of <count> pseudo-attribute', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							count: {
@@ -104,7 +104,7 @@ describe('configure data', () => {
 		});
 		test('base case of <count> pseudo-attribute with closest', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							count: {
@@ -120,7 +120,7 @@ describe('configure data', () => {
 		});
 		test('advanced case of <count> pseudo-attribute with not found closest', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							count: {
@@ -136,7 +136,7 @@ describe('configure data', () => {
 		});
 		test('advanced case of <count> pseudo-attribute with not found closest and value selector', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							count: {
@@ -155,7 +155,7 @@ describe('configure data', () => {
 		});
 		test('advanced case of a object <text> value', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							sectionTitle: {
@@ -171,7 +171,7 @@ describe('configure data', () => {
 		});
 		test('advanced case of a object attribute value', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							sectionIndex: {
@@ -187,7 +187,7 @@ describe('configure data', () => {
 		});
 		test('advanced case of a array of resolver strings, returning first match', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							id: ['id', 'data-spotlight-id', 'data-component-id']
@@ -200,7 +200,7 @@ describe('configure data', () => {
 		});
 		test('advanced case of a array of resolver value objects, returning first match', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							sectionIndex: [
@@ -225,7 +225,7 @@ describe('configure data', () => {
 	describe('#closest', () => {
 		test('base case of using closest where data is found', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							sectionIndex: {
@@ -241,7 +241,7 @@ describe('configure data', () => {
 		});
 		test('base case of using closest where nothing is found', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							sectionIndex: {
@@ -260,7 +260,7 @@ describe('configure data', () => {
 	describe('#selector', () => {
 		test('base case of using selector where data is found', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							iconUrl: {
@@ -276,7 +276,7 @@ describe('configure data', () => {
 		});
 		test('base case of using selector where nothing is found', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							iconUrl: {
@@ -295,7 +295,7 @@ describe('configure data', () => {
 	describe('#matches', () => {
 		test('base case of using matches where data is found', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							iconUrl: {
@@ -313,7 +313,7 @@ describe('configure data', () => {
 		});
 		test('base case of using matches where nothing is found', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							iconUrl: {
@@ -333,7 +333,7 @@ describe('configure data', () => {
 	describe('#expression', () => {
 		test('base case of using expression where data is matched', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							avatarHost: {
@@ -350,7 +350,7 @@ describe('configure data', () => {
 		});
 		test('base case of using expression where nothing is matched', () => {
 			const cfg = {
-				entries: [
+				rules: [
 					{
 						data: {
 							avatarHost: {

--- a/tests/log-specs.js
+++ b/tests/log-specs.js
@@ -3,7 +3,7 @@ import {log as logger, configure} from '..';
 describe('log', () => {
 	test('imperatively pass log extries into the analytics system', () => {
 		const log = jest.fn();
-		configure({enabled:true, log, idle: false});
+		configure({enabled:true, log, entries: [{}], idle: false});
 		logger({customData: true, target: document});
 		expect(log.mock.calls[0][0].customData).toBeTruthy();
 	});

--- a/tests/log-specs.js
+++ b/tests/log-specs.js
@@ -3,7 +3,7 @@ import {log as logger, configure} from '..';
 describe('log', () => {
 	test('imperatively pass log extries into the analytics system', () => {
 		const log = jest.fn();
-		configure({enabled:true, log, entries: [{}], idle: false});
+		configure({enabled:true, log, rules: [{}], idle: false});
 		logger({customData: true, target: document});
 		expect(log.mock.calls[0][0].customData).toBeTruthy();
 	});

--- a/tests/log-specs.js
+++ b/tests/log-specs.js
@@ -3,7 +3,7 @@ import {log as logger, configure} from '..';
 describe('log', () => {
 	test('imperatively pass log extries into the analytics system', () => {
 		const log = jest.fn();
-		configure({enabled:true, log, rules: [{}], idle: false});
+		configure({enabled:true, log, idle: false});
 		logger({customData: true, target: document});
 		expect(log.mock.calls[0][0].customData).toBeTruthy();
 	});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -3,7 +3,16 @@ import {mount} from 'enzyme';
 import React from 'react';
 
 const defaultTarget = '#test-target';
-const defaultConfig = {enabled: true, selector: '[id]', idle: false};
+const defaultConfig = {
+	enabled: true,
+	selector: '[id]',
+	idle: false,
+	entries: [
+		{
+			data: {}
+		}
+	]
+};
 const container = document.body.appendChild(document.createElement('div'));
 
 // Keymap for keydown usage

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -7,7 +7,7 @@ const defaultConfig = {
 	enabled: true,
 	selector: '[id]',
 	idle: false,
-	entries: [
+	rules: [
 		{
 			data: {}
 		}

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -6,12 +6,7 @@ const defaultTarget = '#test-target';
 const defaultConfig = {
 	enabled: true,
 	selector: '[id]',
-	idle: false,
-	rules: [
-		{
-			data: {}
-		}
-	]
+	idle: false
 };
 const container = document.body.appendChild(document.createElement('div'));
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The original design of the analytics module assumed that authors would want to track "most" user interactions. This assumption drove the design decisions of top-level configurations for `include`, `exclude`, `filter`, and `data`.

New user requirements and internal discussions pointed out that it's more common to identify specific elements/features to be tracked and define rules and data around those interactions. This isn't easily supported via the top-level configuration options.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Add a new `rules` collection to the config object that defines the rules and data for each
* Change `include`, `exclude`, `filter`, and `data` to be per-entry options rather than top-level options

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In order to filter the message correctly, each rule's `data` set must be resolved even if it is then discarded by the filter. I've not attempted to optimize that logic yet but could be investigated later (e.g. memoizing the result of resolvers so that common look ups can be short circuited). 
