### PR TITLE
ENYO-6070: Change include to require matching all conditions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -255,10 +255,26 @@ const buildRuleset = ruleset => Object.keys(ruleset).reduce((result, key) => {
 	return result;
 }, {});
 
+const matchesRule = (rule, value) => value && rule.test(value);
+
+const matchesRules = (ruleset, msg) => {
+	const keys = Object.keys(ruleset);
+	const count = keys.filter(key => matchesRule(ruleset[key], msg[key])).length;
+
+	switch (count) {
+		case 0:
+			return 'NONE';
+		case keys.length:
+			return 'ALL';
+		default:
+			return 'SOME';
+	}
+};
+
 // Determines if the message matches a set of rules
-const matchesRules = (ruleset, msg) => Object.keys(ruleset).some(key => {
-	return !!msg[key] && ruleset[key].test(msg[key]);
-});
+const matchesAnyRules = (ruleset, msg) => matchesRules(ruleset, msg) !== 'NONE';
+
+const matchesAllRules = (ruleset, msg) => matchesRules(ruleset, msg) === 'ALL';
 
 const getFirstNode = (nodeOrList) => {
 	return nodeOrList instanceof global.HTMLElement ? nodeOrList : nodeOrList[0];
@@ -399,9 +415,10 @@ const buildDataResolver = (data) => {
 // filter function.
 const filter = (entry, msg) => {
 	if (
-		(entry.exclude && matchesRules(entry.exclude, msg)) ||
-		(entry.include && !matchesRules(entry.include, msg))
+		(entry.exclude && matchesAnyRules(entry.exclude, msg)) ||
+		(entry.include && !matchesAllRules(entry.include, msg))
 	) {
+
 		return false;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ const logQueue = [];
  * ```
  * {
  *     include: {
- *         // mapping of message key to strings of which the message must include at least one
+ *         // mapping of message key to strings of which the message must include all
  *         panel: 'HOME'
  *     },
  *     exclude: {
@@ -184,7 +184,7 @@ const logQueue = [];
  * @property {String[]|Object.<String, Listener>} [listeners] Array of events or object mapping events to filter
  *                                               functions.
  * @property {Function} log Required application-defined function to log the events
- * @property {Rules[]} [rules] A set of rules defining the data to be collected.
+ * @property {Entry[]} [rules] A set of rules defining the data to be collected.
  * @property {String} [selector] A CSS selector which finds the closest ancestor from the target of an
  *                             event to consider as the source for the purposes of logging
  */

--- a/src/index.js
+++ b/src/index.js
@@ -303,7 +303,11 @@ const resolveAttribute = (name) => (node) => {
 		return first.type === 'password' ? null : first.value;
 	}
 
-	return first.getAttribute(name.substr(1));
+	if (first instanceof global.HTMLElement) {
+		return first.getAttribute(name.substr(1));
+	}
+
+	return null;
 };
 
 /**

--- a/tests/configure-specs.js
+++ b/tests/configure-specs.js
@@ -101,6 +101,11 @@ describe('configure', () => {
 			const log = mountTriggerEvent({rules: [{include}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(1);
 		});
+		test('existing keys, which does not match all conditions, allows log entry in output', () => {
+			const include = {label: ['Click', 'Other'], alt: 'alt'};
+			const log = mountTriggerEvent({rules: [{include, data: {alt: '@alt'}}], target: '#test-target'});
+			expect(log.mock.calls.length).toBe(0);
+		});
 	});
 
 	describe('#filter', () => {

--- a/tests/configure-specs.js
+++ b/tests/configure-specs.js
@@ -101,7 +101,7 @@ describe('configure', () => {
 			const log = mountTriggerEvent({rules: [{include}], target: '#aria-button'});
 			expect(log.mock.calls.length).toBe(1);
 		});
-		test('existing keys, which does not match all conditions, allows log entry in output', () => {
+		test('existing keys, which do not match all conditions, excludes log entry in output', () => {
 			const include = {label: ['Click', 'Other'], alt: 'alt'};
 			const log = mountTriggerEvent({rules: [{include, data: {alt: '@alt'}}], target: '#test-target'});
 			expect(log.mock.calls.length).toBe(0);


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed

* [X] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Previously, `include` and `exclude` conditions used "matches any" heuristics. This made sense when those keys were at the root but having moved them into the `rules` array, it _might_ make sense to make `include` use "matches all" but keep `exclude` using "matches any".

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change the `include` rule evaluation to use "matches all".
